### PR TITLE
v2.0.1: dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.0.1: Dependency bumps
+
+Compiled against the current Silksong runtime and the latest helper packages, so the Thunderstore install pulls newer dependency versions automatically. No code changes from 2.0.0.
+
+- `Silksong.GameLibs` 1.0.29315 -> 1.0.30000 (matches the current Silksong build).
+- `silksong_modding-DataManager` 1.2.1 -> 1.2.2.
+- `silksong_modding-FsmUtil` 0.3.13 -> 0.3.16.
+- `silksong_modding-UnityHelper` 1.1.1 -> 1.2.0.
+- `softprops/action-gh-release` 2 -> 3 in the publish workflow.
+
 ## v2.0.0: Wishes Overhaul
 
 Big one. Rewrites the entire All Wishes Mode plumbing, ships full quest customization (rules engine with presets, tags, and per quest policies), opens up all three wishwalls, lets you complete wishes from anywhere, fixes the four open NPC bugs, and adds a save safety gate so legacy saves never get touched without explicit opt in.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <AssemblyTitle>QuestMod</AssemblyTitle>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 </Project>

--- a/thunderstore/thunderstore.toml
+++ b/thunderstore/thunderstore.toml
@@ -4,16 +4,15 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "DatUub"
 description = "Quest management mod for Silksong — accept, complete, and customize quest targets with a full debug GUI."
-# Bump version for dependency fix
-version = "2.0.0"
+version = "2.0.1"
 websiteUrl = "https://github.com/DatUub/Silksong.QuestMod"
 containsNsfwContent = false
 
 [package.dependencies]
 BepInEx-BepInExPack_Silksong = "5.4.2304"
-silksong_modding-DataManager = "1.2.1"
-silksong_modding-FsmUtil = "0.3.13"
-silksong_modding-UnityHelper = "1.1.1"
+silksong_modding-DataManager = "1.2.2"
+silksong_modding-FsmUtil = "0.3.16"
+silksong_modding-UnityHelper = "1.2.0"
 
 [build]
 icon = "./logo.png"


### PR DESCRIPTION
Compiles against the current Silksong runtime (`Silksong.GameLibs` 1.0.29315 → 1.0.30000) and the latest helper packages so the Thunderstore install pulls newer dependency versions automatically.
No code changes from 2.0.0 — pure version + manifest bump.
- DataManager 1.2.1 → 1.2.2
- FsmUtil 0.3.13 → 0.3.16
- UnityHelper 1.1.1 → 1.2.0
- GameLibs 1.0.29315 → 1.0.30000
- softprops/action-gh-release 2 → 3 (workflow only)